### PR TITLE
Debug asserts and breakpoints

### DIFF
--- a/include/lug/System/Debug.hpp
+++ b/include/lug/System/Debug.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <lug/Config.hpp>
+#include <lug/System/Utils.hpp>
+#include <iostream>
+
+
+#if defined(LUG_DEBUG)
+
+    #if defined(LUG_COMPILER_GCC) || defined(LUG_COMPILER_CLANG)
+
+        #define LUG_DEBUG_BREAK() __asm__("int $3")
+
+    #elif defined(LUG_COMPILER_MSVC)
+
+        #define LUG_DEBUG_BREAK() __debugbreak()
+
+    #endif
+
+
+    #define LUG_ASSERT(assertion, message)\
+    do {\
+        if (LUG_UNLIKELY(!(assertion))) {\
+            std::cerr << "Assertion failed: " << (message) << std::endl <<\
+            "In " << __FILE__ << std::endl <<\
+            " at `" << LUG_SYSTEM_FUNCTION_NAME << "` line " << __LINE__ << std::endl;\
+            LUG_DEBUG_BREAK();\
+        }\
+    } while (0)
+
+#else
+
+    #define LUG_ASSERT(assertion, message)
+    #define LUG_DEBUG_BREAK()
+
+#endif

--- a/include/lug/System/Exception.hpp
+++ b/include/lug/System/Exception.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <string>
 #include <lug/System/Export.hpp>
+#include <lug/System/Utils.hpp>
 
 
 namespace lug {
@@ -85,12 +86,6 @@ public:
     : Exception{"WindowException", description, file, function, line} {}
 };
 
-
-#if defined(LUG_COMPILER_MSVC)
-    #define LUG_SYSTEM_FUNCTION_NAME __FUNCSIG__
-#else
-    #define LUG_SYSTEM_FUNCTION_NAME __PRETTY_FUNCTION__
-#endif
 
 #define LUG_EXCEPT(type, desc)\
 do {\

--- a/include/lug/System/Utils.hpp
+++ b/include/lug/System/Utils.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+
+#if defined(LUG_COMPILER_MSVC)
+    #define LUG_SYSTEM_FUNCTION_NAME __FUNCSIG__
+#else
+    #define LUG_SYSTEM_FUNCTION_NAME __PRETTY_FUNCTION__
+#endif
+
+
+#if defined(__clang__) || defined(__GNUC__)
+
+    #define LUG_LIKELY(x) __builtin_expect(!!(x), 1)
+    #define LUG_UNLIKELY(x) __builtin_expect(!!(x), 0)
+
+#else
+
+    #define LUG_LIKELY(x) (x)
+    #define LUG_UNLIKELY(x) (x)
+
+#endif

--- a/src/lug/System/CMakeLists.txt
+++ b/src/lug/System/CMakeLists.txt
@@ -9,6 +9,7 @@ source_group("src" FILES ${SRC})
 
 # all header files
 set(INC
+    ${INCROOT}/Debug.hpp
     ${INCROOT}/Exception.hpp
     ${INCROOT}/Export.hpp
 )

--- a/src/lug/System/Exception.cpp
+++ b/src/lug/System/Exception.cpp
@@ -29,7 +29,7 @@ const char* lug::System::Exception::what() const noexcept {
 
     msg << _typeName << ": " << _description << std::endl;
     msg << "In " << _file;
-    msg << " at " << _function << " line " << _line;
+    msg << " at `" << _function << "` line " << _line;
 
     _fullDesc = msg.str();
     return _fullDesc.c_str();


### PR DESCRIPTION
Test main:

```
#include <lug/System/Debug.hpp>

int main() {
    LUG_ASSERT(1 == 1, "not functionning");
    std::cout << "hello" << std::endl;
    return 0;
}
```
- Asserts and breakpoints are disabled on release
- **Not** tested on windows
