### PR TITLE
Fix vulkan objects destruction errors

### DIFF
--- a/include/lug/Graphics/Vulkan/Gui.hpp
+++ b/include/lug/Graphics/Vulkan/Gui.hpp
@@ -67,6 +67,8 @@ public:
 
     ~Gui();
 
+    void destroy();
+
     bool init(const std::vector<API::ImageView>& imageViews);
     void initKeyMapping();
     bool initFontsTexture();

--- a/src/lug/Graphics/Vulkan/API/Device.cpp
+++ b/src/lug/Graphics/Vulkan/API/Device.cpp
@@ -91,6 +91,8 @@ bool Device::waitIdle() const {
 }
 
 void Device::destroy() {
+    _queueFamilies.clear();
+
     if (_device != VK_NULL_HANDLE) {
         vkDeviceWaitIdle(_device);
         vkDestroyDevice(_device, nullptr);

--- a/src/lug/Graphics/Vulkan/Gui.cpp
+++ b/src/lug/Graphics/Vulkan/Gui.cpp
@@ -21,6 +21,19 @@ Gui::Gui(lug::Graphics::Vulkan::Renderer& renderer, lug::Graphics::Vulkan::Rende
 }
 
 Gui::~Gui() {
+    destroy();
+}
+
+void Gui::destroy() {
+    _fontImage.destroy();
+    _fontImageView.destroy();
+    _fontDeviceMemory.destroy();
+    _fontSampler.destroy();
+
+    _descriptorPool.destroy();
+
+    _pipeline.destroy();
+
     for (const auto& frameData: _framesData) {
         if (frameData.vertexMemoryPtr) {
             frameData.vertexMemory.unmap();
@@ -30,6 +43,14 @@ Gui::~Gui() {
             frameData.indexMemory.unmap();
         }
     }
+
+    _framesData.clear();
+
+    _graphicQueueCommandPool.destroy();
+    _transferQueueCommandPool.destroy();
+
+    _graphicQueue = nullptr;
+    _transferQueue = nullptr;
 }
 
 bool Gui::init(const std::vector<API::ImageView>& imageViews) {

--- a/src/lug/Graphics/Vulkan/Render/Window.cpp
+++ b/src/lug/Graphics/Vulkan/Render/Window.cpp
@@ -593,6 +593,8 @@ void Window::destroyRender() {
     _acquireImageDatas.clear();
 
     _commandPool.destroy();
+
+    _guiInstance.destroy();
 }
 
 } // Render

--- a/src/lug/Graphics/Vulkan/Renderer.cpp
+++ b/src/lug/Graphics/Vulkan/Renderer.cpp
@@ -64,6 +64,7 @@ void Renderer::destroy() {
     _window.reset();
 
     _resourceManager.reset();
+    _pipelines.clear();
 
     _device.destroy();
 
@@ -102,6 +103,9 @@ bool Renderer::finishInit() {
         if (_window) {
             _window->destroyRender();
         }
+
+        _resourceManager.reset();
+        _pipelines.clear();
 
         _device.destroy();
     }


### PR DESCRIPTION
When calling Application::finishInit with different devices, it does not destroy and recreate the device/window/renderer resources correctly